### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/iobroker-community-adapters/ioBroker.worx.git"
   },
   "engines": {
-    "node": ">= 14.18.0"
+    "node": ">= 16"
   },
   "dependencies": {
     "@alcalzone/release-script": "^3.6.0",


### PR DESCRIPTION
require node 16 as adapter-core 3.x.x. fails to install with node 14.

Please increase minor version number with next release